### PR TITLE
Throw non-JSON responses as errors

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -216,10 +216,15 @@ export function fetchReq<I, O>(path: string, init?: InitReq): Promise<O> {
 
   const url = pathPrefix ? ` + "`${pathPrefix}${path}`" + ` : path
 
-  return fetch(url, req).then(r => r.json().then((body: O) => {
-    if (!r.ok) { throw body; }
-    return body;
-  })) as Promise<O>
+  return fetch(url, req).then((r) =>
+    r
+      .json()
+      .catch((err) => { throw r; })
+      .then((body: O) => {
+        if (!r.ok) { throw body; }
+        return body;
+      }),
+   ) as Promise<O>;
 }
 
 // NotifyStreamEntityArrival is a callback that will be called on streaming entity arrival


### PR DESCRIPTION
This allows us to support the `{ redirect: 'manual' }` option, giving us access to the browser's response object with `type: "opaqueredirect"`, which allows us to reliably detect the redirect case.