### PR TITLE
Update Typescript types to match what our server returns

### DIFF
--- a/data/file.go
+++ b/data/file.go
@@ -51,6 +51,16 @@ func (f *File) NeedsOneOfSupport() bool {
 	return false
 }
 
+func (f *File) NeedsStructPBSupport() bool {
+	for _, m := range f.Messages {
+		if m.HasStructPBFields() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // TrackPackageNonScalarType tracks the supplied non scala type in the same package
 func (f *File) TrackPackageNonScalarType(t Type) {
 	isNonScalarType := strings.Index(t.GetType().Type, ".") == 0

--- a/data/message.go
+++ b/data/message.go
@@ -27,6 +27,22 @@ func (m *Message) HasOneOfFields() bool {
 	return len(m.OneOfFieldsGroups) > 0
 }
 
+func (m *Message) HasStructPBFields() bool {
+	for _, f := range m.Fields {
+		if f.Type == ".google.protobuf.ListValue" || f.Type == ".google.protobuf.Struct" {
+			return true
+		}
+	}
+
+	for _, mm := range m.Messages {
+		if mm.HasStructPBFields() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // NewMessage initialises and return a Message
 func NewMessage() *Message {
 	return &Message{

--- a/generator/template.go
+++ b/generator/template.go
@@ -578,13 +578,13 @@ func mapWellKnownType(protoType string) string {
 func mapScalaType(protoType string) string {
 	switch protoType {
 	case "uint64", "sint64", "int64", "fixed64", "sfixed64", "string":
-		return "string | null"
+		return "string"
 	case "float", "double", "int32", "sint32", "uint32", "fixed32", "sfixed32":
-		return "number | null"
+		return "number"
 	case "bool":
-		return "boolean | null"
+		return "boolean"
 	case "bytes":
-		return "Uint8Array | null"
+		return "Uint8Array"
 	}
 
 	return ""

--- a/generator/template.go
+++ b/generator/template.go
@@ -558,16 +558,18 @@ func tsType(r *registry.Registry, fieldType data.Type) string {
 func mapWellKnownType(protoType string) string {
 	switch protoType {
 	case ".google.protobuf.BoolValue":
-		return "boolean | undefined"
+		return "boolean | null"
 	case ".google.protobuf.StringValue":
-		return "string | undefined"
+		return "string | null"
 	case ".google.protobuf.DoubleValue",
 		".google.protobuf.FloatValue",
 		".google.protobuf.Int32Value",
 		".google.protobuf.Int64Value",
 		".google.protobuf.UInt32Value",
 		".google.protobuf.UInt64Value":
-		return "number | undefined"
+		return "number | null"
+	case ".google.protobuf.ListValue":
+		return "T[]"
 	}
 
 	return ""
@@ -576,13 +578,13 @@ func mapWellKnownType(protoType string) string {
 func mapScalaType(protoType string) string {
 	switch protoType {
 	case "uint64", "sint64", "int64", "fixed64", "sfixed64", "string":
-		return "string"
+		return "string | null"
 	case "float", "double", "int32", "sint32", "uint32", "fixed32", "sfixed32":
-		return "number"
+		return "number | null"
 	case "bool":
-		return "boolean"
+		return "boolean | null"
 	case "bytes":
-		return "Uint8Array"
+		return "Uint8Array | null"
 	}
 
 	return ""

--- a/generator/template.go
+++ b/generator/template.go
@@ -84,6 +84,15 @@ type OneOf<T> =
         : never)
     : never);
 {{end}}
+{{- if .NeedsStructPBSupport}}
+type StructPBValue =
+  | null
+  | boolean
+  | string
+  | number
+  | { [key: string]: StructPBValue }
+  | StructPBValue[];
+{{end}}
 {{- if .Enums}}{{include "enums" .Enums}}{{end}}
 {{- if .Messages}}{{include "messages" .Messages}}{{end}}
 {{- if .Services}}{{include "services" .Services}}{{end}}
@@ -569,7 +578,9 @@ func mapWellKnownType(protoType string) string {
 		".google.protobuf.UInt64Value":
 		return "number | null"
 	case ".google.protobuf.ListValue":
-		return "T[]"
+		return "StructPBValue[]"
+	case ".google.protobuf.Struct":
+		return "{ [key: string]: StructPBValue }"
 	}
 
 	return ""


### PR DESCRIPTION
Should fix issue https://github.com/BeProductable/productable-mvp/issues/1403

We noticed that this library was generating Typescript types such as `number | undefined` when our server was returning `number | null` which has been inconvenient when comparing two empty values because `undefined != null`. 

To fix this, we can update this library to return Typescript types that match what our server is returning. For all empty values, we will return `null` instead of `undefined`. 

This PR also generates the correct Typescript type for `google.protobuf.ListValue`.


