### PR TITLE
Add FieldMask support

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -581,6 +581,8 @@ func mapWellKnownType(protoType string) string {
 		return "StructPBValue[]"
 	case ".google.protobuf.Struct":
 		return "{ [key: string]: StructPBValue }"
+	case ".google.protobuf.FieldMask":
+		return "string | null"
 	}
 
 	return ""


### PR DESCRIPTION
I'm experimenting with using [FieldMasks](https://protobuf.dev/reference/protobuf/google.protobuf/#field-mask) in our service for defining which fields are included (or omitted) in responses. As part of that, I want to make field masks supported in our TypeScript type generation.

I tested this out with a local debug endpoint, and here's what's accepted:

FieldMask as input in a request message:
- No value (omitted)
- String with comma-separated paths (e.g. "one,two,three.a,three.b")

FieldMask as output in a response message (this won't typically be used, but it's nice for completeness):
- `null` if not set
- String with comma-separated paths (same as the input format)

So this change should cover it 👍 